### PR TITLE
Getting threads by label, instead of by search string.

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -15,13 +15,11 @@
 
     Logger.log("Beginning MAIN  Run");
     SetVars();
-    threads = getThreads(getProp('PROCESS_LABEL'));
+    // threads = getThreads(getProp('PROCESS_LABEL'));
+    threads = getThreadsByLabel(getProp('PROCESS_LABEL'));
     if(threads.length == 0) {
       Logger.log("No threads  to process");
       return;
-    }
-    else {
-      Logger.log("Found threads to process: " + threads.length);
     }
     runThreads(threads);
   }  
@@ -84,7 +82,7 @@ Logger.log("BEGINNING LOOPING::");
 /**
  * getThreads
  * 
- * Retuns an array of Thread objects with a particular label
+ * Retuns an array of Thread objects by search string
  * 
  * @param {string} strCriteria Label gmail search criteria string
  * @return array of Thread objects that match search criteria
@@ -94,6 +92,26 @@ function getThreads(strSearch){
 
   Logger.log(" - SEARCHING INBOX FOR THREADS WITH LABEL: " + strSearch);  
   threads = GmailApp.search('label: ' + strSearch);
+  return threads;
+}
+
+/**
+ * getThreadsByLabel
+ * 
+ * Returns all threads with a given label
+ * 
+ * @param {string} strLabel Label to search threads
+ * @return array of Thread objects that match search criteria
+ */
+function getThreadsByLabel(strLabel) {
+  if (strLabel == '') {
+    throw new Error('getThreadsByLabel: Null label passed to function');
+  }
+  var label = GmailApp.getUserLabelByName(strLabel);
+  if (label == '') {
+    throw new Error('getThreadsByLabel: Label not found: ' + strLabel);
+  }
+  var threads = label.getThreads();
   return threads;
 }
 

--- a/settings.gs
+++ b/settings.gs
@@ -24,7 +24,7 @@ function getProp(key) {
 
 function SetVars() {
 
-  setProp('DEBUG', '1');
+  setProp('DEBUG', '0');
   var replyFile  = "Std Reply 2022"
   var attachFile = "Don_Briggs_Resume_2022.pdf";
 


### PR DESCRIPTION
I don't know why it was not always this way. But it's fixed now.